### PR TITLE
Add TypeScript Declaration

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,37 @@
+declare module 'markdown-it-github-headings' {
+  import type { PluginWithOptions } from 'markdown-it';
+  type GithubHeadingsPluginOptions = {
+    /**
+     * Name of the class that will be added to the anchor tag.
+     * @default "anchor"
+     */
+    className?: string;
+    /**
+     * Add a prefix to each heading ID.
+     * @see https://github.com/Flet/markdown-it-github-headings#why-should-i-prefix-heading-ids
+     * @default true
+     */
+    prefixHeadingIds?: boolean;
+    /**
+     * If `prefixHeadingIds` is true, use this string to prefix each ID.
+     * @default "user-content"
+     */
+    prefix?: string;
+    /**
+     * Adds the icon next to each heading.
+     * @default true
+     */
+    enableHeadingLinkIcons?: boolean;
+    /**
+     * If `enableHeadingLinkIcons` is true, use this to supply a custom icon (or anything really).
+     */
+    linkIcon?: string;
+    /**
+     * Reset the slugger counter between .render calls for duplicate headers. (See tests for example).
+     * @default true
+     */
+    resetSlugger?: boolean;
+  };
+  const markdownItGithubHeadings: PluginWithOptions<GithubHeadingsPluginOptions>;
+  export = markdownItGithubHeadings;
+}

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   ],
   "license": "ISC",
   "main": "index.js",
+  "types": "index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/Flet/markdown-it-github-headings.git"


### PR DESCRIPTION
This PR aims to add a typescript declaration to the library. So typescript users can use this library without ignoring declaration errors. I'm also adding comments to the options according to the [README.md](https://github.com/Flet/markdown-it-github-headings#options-and-defaults). 